### PR TITLE
List required PHP extensions in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,7 @@
 {
     "require": {
+        "ext-curl": "*",
+        "ext-zlib": "*",
         "symfony/filesystem": "^4.4",
         "symfony/finder": "^4.4",
         "symfony/lock": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
+        "php": "^7.1",
         "ext-curl": "*",
         "ext-zlib": "*",
         "symfony/filesystem": "^4.4",


### PR DESCRIPTION
I couldn't figure out what the minimum PHP version was, it would be nice if that could be specified too.