### PR TITLE
More verbosity and delayed retries

### DIFF
--- a/mirror.php
+++ b/mirror.php
@@ -131,7 +131,7 @@ class Mirror {
             throw new \UnexpectedValueException('Cannot save last timestamp to last_metadata_timestamp in '.getcwd().'. Make sure the file is writable.');
         }
         $lastTime = trim(file_get_contents($this->getTimestampStorePath()));
-        $this->out('Last update was on '.new DateTimeExt($lastTime));
+        $this->output('Last update was on '.new DateTimeExt($lastTime).PHP_EOL);
         $changesResp = $this->client->request('GET', $this->apiUrl.'/metadata/changes.json?since='.$lastTime, ['headers' => ['Host' => parse_url($this->apiUrl, PHP_URL_HOST)]]);
         if ($changesResp->getHeaders()['content-encoding'][0] !== 'gzip') {
             throw new \Exception('Expected gzip encoded responses, something is off');

--- a/mirror.php
+++ b/mirror.php
@@ -147,7 +147,6 @@ class Mirror {
                 $this->delete($action['package']);
             }
         }
-        sleep(1);
         $result = $this->downloadV2Files($requests);
         if (!$result) {
             return false;


### PR DESCRIPTION
This PR adds 
- [x] more retries, with delay
For a reason that I can't explain when has_v1_mirror is true, some downloads fails, it seems that retrying immediately doesn't helps to recover everytime the things. Adding a fixed pause (i.e. : 1 second in commit 1066162) does not seems to be always sufficient. Calming more and more down the little :rabbit: forces him to gather things much better !  :stuck_out_tongue_winking_eye:
- [x] verbosity (while using -v)


Output show between between brackets show the number of retries.

 * `time ./mirror --v2 -v`, from empty folder, started 2021-06-12T09:29PM UTC, 

Seen at the end of the process :
>....MMR[1]R[1]R[1]R[1]R[1]R[1]R[2]R[2]R[2]R[2]R[2]R[2]R[3]R[3]R[3]R[3]R[3]R[3]R[4]R[4]R[4]R[4]R[4]R[4]R[5]R[5]R[5]R[5]R[5]R[5]R[6]R[6]R[6]R[6]R[6]R[6]R[7]R[7]R[7]R[7]R[7]R[7]R[8]R[8]R[8]R[8]R[8]R[8]R[9]R[9]R[9]R[9]R[9]R[9]R[10]R[10]R[10]R[10]R[10]R[10]??????
> Downloaded 611665 files
> real	33m23,535s
> user	9m41,809s
> sys	2m5,659s

 * `time ./mirror.php --resync -v` started at 2021-06-1210:16PMUTC
Seen at the end of the process :

> ---R[1]R[1]R[1]R[1]R[1]R[1]R[2]R[2]R[2]R[2]R[2]R[2]R[3]R[3]R[3]R[3]R[3]R[3]R[4]R[4]R[4]R[4]R[4]R[4]R[5]R[5]R[5]R[5]R[5]R[5]R[6]R[6]R[6]R[6]R[6]R[6]R[7]R[7]R[7]R[7]R[7]R[7]R[8]R[8]R[8]
> R[8]R[8]R[8]R[9]R[9]R[9]R[9]R[9]R[9]R[10]R[10]R[10]R[10]R[10]R[10]??????
> Downloaded 611667 files
> 
> real	27m6,411s
> user	7m5,421s
> sys	1m5,743s


The mirror is fully operationnal
```
composer config repos.packagist composer https://mirror-composer.lan/
composer require drush/drush
```
>[...]
>14 package suggestions were added by new dependencies, use `composer suggest` to see details.
